### PR TITLE
fix: odatav4 filter for cap backends

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -344,7 +344,9 @@ func (c *ODataClient) GetEntitySet(ctx context.Context, entitySet string, option
 	}
 	
 	if len(params) > 0 {
-		endpoint += "?" + params.Encode()
+		encodedQuery := params.Encode()
+		// Replace '+' with '%20' for compatibility with servers that don't accept '+' for spaces.
+		endpoint += "?" + strings.ReplaceAll(encodedQuery, "+", "%20")
 	}
 
 	req, err := c.buildRequest(ctx, constants.GET, endpoint, nil)
@@ -376,7 +378,9 @@ func (c *ODataClient) GetEntity(ctx context.Context, entitySet string, key map[s
 			}
 		}
 		if len(params) > 0 {
-			endpoint += "?" + params.Encode()
+			encodedQuery := params.Encode()
+		// Replace '+' with '%20' for compatibility with servers that don't accept '+' for spaces.
+		endpoint += "?" + strings.ReplaceAll(encodedQuery, "+", "%20")
 		}
 	}
 

--- a/internal/test/entity_retrieval_test.go
+++ b/internal/test/entity_retrieval_test.go
@@ -189,12 +189,12 @@ func TestEntityFilter(t *testing.T) {
 			{
 				name:           "Simple string filter",
 				filter:         "Program eq 'ZHELLO_GO_TEST'",
-				expectedFilter: "Program+eq+%27ZHELLO_GO_TEST%27",
+				expectedFilter: "Program%20eq%20%27ZHELLO_GO_TEST%27",
 			},
 			{
 				name:           "Filter with package",
 				filter:         "Package eq '$VIBE_TEST'",
-				expectedFilter: "Package+eq+%27%24VIBE_TEST%27",
+				expectedFilter: "Package%20eq%20%27%24VIBE_TEST%27",
 			},
 		}
 		


### PR DESCRIPTION
I am using this current version to talk to my CAP ODataV4 service.