### PR TITLE
Added a new flag to forward MCP headers to the OData endpoint.

### DIFF
--- a/cmd/odata-mcp/main.go
+++ b/cmd/odata-mcp/main.go
@@ -121,6 +121,9 @@ func init() {
 	// Protocol version override (for AI Foundry compatibility)
 	rootCmd.Flags().StringVar(&cfg.ProtocolVersion, "protocol-version", "", "Override MCP protocol version (e.g., '2025-06-18' for AI Foundry)")
 
+	// Header forwarding (HTTP transport only)
+	rootCmd.Flags().BoolVar(&cfg.ForwardMCPHeaders, "forward-mcp-headers", false, "Forward HTTP headers from MCP connection to OData service (Streamable HTTP transport only)")
+
 	// Bind flags to viper for environment variable support
 	viper.BindPFlag("service", rootCmd.Flags().Lookup("service"))
 	viper.BindPFlag("username", rootCmd.Flags().Lookup("user"))
@@ -306,8 +309,11 @@ func runBridge(cmd *cobra.Command, args []string) error {
 			fmt.Fprintf(os.Stderr, "[VERBOSE] Starting Streamable HTTP transport (protocol 2024-11-05) on %s\n", httpAddr)
 			fmt.Fprintf(os.Stderr, "[VERBOSE] Main endpoint: http://%s/mcp\n", httpAddr)
 			fmt.Fprintf(os.Stderr, "[VERBOSE] Health endpoint: http://%s/health\n", httpAddr)
+			if cfg.ForwardMCPHeaders {
+				fmt.Fprintf(os.Stderr, "[VERBOSE] Header forwarding enabled - HTTP headers will be passed to OData service\n")
+			}
 		}
-		trans = http.NewStreamableHTTP(httpAddr, handler, expertMode)
+		trans = http.NewStreamableHTTP(httpAddr, handler, expertMode, cfg.ForwardMCPHeaders)
 	case "http", "sse":
 		httpAddr, _ := cmd.Flags().GetString("http-addr")
 		expertMode, _ := cmd.Flags().GetBool("i-am-security-expert-i-know-what-i-am-doing")

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -17,6 +17,11 @@ import (
 	"github.com/zmcp/odata-mcp/internal/models"
 )
 
+// Context key for HTTP headers passed from MCP server
+type contextKey string
+
+const HTTPHeadersContextKey contextKey = "mcp-http-headers"
+
 // ODataClient handles HTTP communication with OData services
 type ODataClient struct {
 	baseURL        string
@@ -83,9 +88,31 @@ func (c *ODataClient) buildRequest(ctx context.Context, method, endpoint string,
 		req.Header.Set(constants.Accept, constants.ContentTypeJSON)
 	}
 
-	// Set authentication
+	// Apply headers from context (from MCP HTTP connection) - do this BEFORE config-based auth
+	// This allows dynamic headers from MCP connection to be used
+	if headers, ok := ctx.Value(HTTPHeadersContextKey).(http.Header); ok {
+		var headerCount int
+		for key, values := range headers {
+			// Skip headers that shouldn't be forwarded
+			if shouldForwardHeader(key) {
+				for _, value := range values {
+					req.Header.Add(key, value)
+					headerCount++
+				}
+			}
+		}
+		if c.verbose && headerCount > 0 {
+			fmt.Fprintf(os.Stderr, "[VERBOSE] Applied %d header(s) from MCP context\n", headerCount)
+		}
+	}
+
+	// Set authentication from configuration (will override context headers if both exist)
+	// This maintains backward compatibility with existing config-based auth
 	if c.username != "" && c.password != "" {
 		req.SetBasicAuth(c.username, c.password)
+		if c.verbose {
+			fmt.Fprintf(os.Stderr, "[VERBOSE] Using configured basic auth\n")
+		}
 	}
 
 	// Set cookies
@@ -277,6 +304,48 @@ func min(a, b int) int {
 		return a
 	}
 	return b
+}
+
+// function that determines if a header should be forwarded from MCP to OData service
+func shouldForwardHeader(headerName string) bool {
+	// Normalize to lowercase for comparison
+	lower := strings.ToLower(headerName)
+
+	// Allow authentication headers
+	if lower == "authorization" || lower == "cookie" {
+		return true
+	}
+
+	// Allow custom headers (X- prefix)
+	if strings.HasPrefix(lower, "x-") {
+		return true
+	}
+
+	// Block hop-by-hop headers and other problematic headers
+	blockedHeaders := []string{
+		"host",
+		"connection",
+		"keep-alive",
+		"transfer-encoding",
+		"upgrade",
+		"proxy-authenticate",
+		"proxy-authorization",
+		"te",
+		"trailer",
+		"content-length", // Will be set by http.Client
+		"content-type",   // Set by specific methods
+		"accept",         // Set by buildRequest
+		"user-agent",     // Set by buildRequest
+	}
+
+	for _, blocked := range blockedHeaders {
+		if lower == blocked {
+			return false
+		}
+	}
+
+	// Allow other headers by default
+	return true
 }
 
 // GetMetadata fetches and parses the OData service metadata

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -66,6 +66,9 @@ type Config struct {
 
 	// Protocol version override (for AI Foundry compatibility)
 	ProtocolVersion string `mapstructure:"protocol_version"` // Override MCP protocol version (default: 2024-11-05)
+
+	// Header forwarding (HTTP transport only)
+	ForwardMCPHeaders bool `mapstructure:"forward_mcp_headers"` // Forward HTTP headers from MCP connection to OData service
 }
 
 // HasBasicAuth returns true if username and password are configured

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -29,6 +29,7 @@ type Request struct {
 	ID      interface{}            `json:"id"`
 	Method  string                 `json:"method"`
 	Params  map[string]interface{} `json:"params,omitempty"`
+	ctx     context.Context        // Request context from transport (not serialized)
 }
 
 // Server represents an MCP server
@@ -60,7 +61,7 @@ func NewServer(name, version string) *Server {
 		toolOrder:       make([]string, 0),
 		handlers:        make(map[string]ToolHandler),
 		ctx:             ctx,
-		cancel:    cancel,
+		cancel:          cancel,
 	}
 }
 
@@ -145,6 +146,7 @@ func (s *Server) HandleMessage(ctx context.Context, msg *transport.Message) (*tr
 		JSONRPC: msg.JSONRPC,
 		ID:      msg.ID,
 		Method:  msg.Method,
+		ctx:     ctx, // Store the request context for passing to handlers
 	}
 
 	// Parse params if present
@@ -323,7 +325,14 @@ func (s *Server) handleToolsCallV2(req *Request) (*transport.Message, error) {
 		return s.createErrorResponse(req.ID, -32602, "Invalid params", fmt.Sprintf("Tool not found: %s", name)), nil
 	}
 
-	result, err := handler(s.ctx, params)
+	// Use request context (from HTTP request) instead of server context to preserve headers
+	handlerCtx := req.ctx
+	if handlerCtx == nil {
+		// Fallback to server context if no request context available (e.g., stdio transport)
+		handlerCtx = s.ctx
+	}
+
+	result, err := handler(handlerCtx, params)
 	if err != nil {
 		// Map OData errors to appropriate MCP error codes and provide detailed context
 		errorCode, errorMessage, errorData := s.categorizeError(err, name)

--- a/internal/transport/http/streamable.go
+++ b/internal/transport/http/streamable.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/zmcp/odata-mcp/internal/client"
 	"github.com/zmcp/odata-mcp/internal/transport"
 )
 
@@ -23,6 +24,7 @@ type StreamableHTTPTransport struct {
 	mu             sync.RWMutex
 	activeStreams  map[string]*streamContext
 	enableSecurity bool
+	forwardHeaders bool // Whether to forward HTTP headers to OData client
 }
 
 type streamContext struct {
@@ -34,12 +36,13 @@ type streamContext struct {
 }
 
 // NewStreamableHTTP creates a new Streamable HTTP transport
-func NewStreamableHTTP(addr string, handler transport.Handler, enableSecurity bool) *StreamableHTTPTransport {
+func NewStreamableHTTP(addr string, handler transport.Handler, enableSecurity bool, forwardHeaders bool) *StreamableHTTPTransport {
 	return &StreamableHTTPTransport{
 		addr:           addr,
 		handler:        handler,
 		activeStreams:  make(map[string]*streamContext),
 		enableSecurity: enableSecurity,
+		forwardHeaders: forwardHeaders,
 	}
 }
 
@@ -95,7 +98,7 @@ func (t *StreamableHTTPTransport) addSecurityHeaders(next http.Handler) http.Han
 		// Add security headers
 		w.Header().Set("X-Content-Type-Options", "nosniff")
 		w.Header().Set("X-Frame-Options", "DENY")
-		
+
 		// CORS headers for local development
 		if isLocalhost(r.Host) {
 			w.Header().Set("Access-Control-Allow-Origin", "*")
@@ -130,8 +133,15 @@ func (t *StreamableHTTPTransport) handleMCP(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	// Process the message
+	// Enrich context with HTTP headers for forwarding to OData service (if enabled)
 	ctx := r.Context()
+	if t.forwardHeaders {
+		// Clone headers to avoid any modification issues
+		headers := r.Header.Clone()
+		ctx = context.WithValue(ctx, client.HTTPHeadersContextKey, headers)
+	}
+
+	// Process the message with enriched context
 	response, err := t.handler(ctx, &msg)
 	if err != nil {
 		response = &transport.Message{
@@ -163,7 +173,7 @@ func (t *StreamableHTTPTransport) handleMCP(w http.ResponseWriter, r *http.Reque
 func (t *StreamableHTTPTransport) shouldUpgradeToStream(request, response *transport.Message) bool {
 	// Check if the response indicates streaming would be beneficial
 	// This could be based on response size, method type, or explicit flags
-	
+
 	// For now, check if it's a method that typically streams
 	streamingMethods := []string{
 		"tools/call",
@@ -279,7 +289,7 @@ func (t *StreamableHTTPTransport) sendSSEMessage(stream *streamContext, eventTyp
 	eventID := fmt.Sprintf("%s-%d", stream.id, time.Now().UnixNano())
 
 	// Send SSE formatted message
-	_, err = fmt.Fprintf(stream.writer, "id: %s\nevent: %s\ndata: %s\n\n", 
+	_, err = fmt.Fprintf(stream.writer, "id: %s\nevent: %s\ndata: %s\n\n",
 		eventID, eventType, jsonData)
 	if err != nil {
 		return err


### PR DESCRIPTION
This PR adds a new feature allows the MCP server to forward any headers sent by the MCP client to the OData endpoint. This can be useful if you are using a secured OData endpoint with custom headers and want to make sure that you authenticate against it and will fail if unauthenticated. It also means that the server could be running and have different credentials being passed on to the OData endpoint on every call of a tool.