### PR TITLE
Feature/sap label support for `odata_service_info_for_Z_V_MM03` with `Include detailed metadata information`

### DIFF
--- a/internal/bridge/bridge.go
+++ b/internal/bridge/bridge.go
@@ -284,6 +284,19 @@ func (b *ODataMCPBridge) mapParameterToOData(param string) string {
 	return param
 }
 
+// describeProperty builds a human-friendly description for a property,
+// including the SAP label when available.
+func (b *ODataMCPBridge) describeProperty(prefix string, prop *models.EntityProperty) string {
+	if prop == nil {
+		return prefix
+	}
+	desc := fmt.Sprintf("%s: %s", prefix, prop.Name)
+	if prop.SAPLabel != nil && *prop.SAPLabel != "" {
+		desc = fmt.Sprintf("%s (%s)", desc, *prop.SAPLabel)
+	}
+	return desc
+}
+
 // generateServiceInfoTool creates a tool to get service information
 func (b *ODataMCPBridge) generateServiceInfoTool() {
 	toolName := b.formatToolName("odata_service_info", "")
@@ -379,7 +392,7 @@ func (b *ODataMCPBridge) generateFilterTool(entitySetName string, entitySet *mod
 		},
 		b.getParameterName("$select"): map[string]interface{}{
 			"type":        "string",
-			"description": "Comma-separated list of properties to select",
+			"description": "Comma-separated list of properties to select (property names; SAP labels are in include_metadata under entity_types_detail.<Entity>.properties[].sap_label)",
 		},
 		b.getParameterName("$expand"): map[string]interface{}{
 			"type":        "string",
@@ -482,7 +495,7 @@ func (b *ODataMCPBridge) generateSearchTool(entitySetName string, entitySet *mod
 				},
 				b.getParameterName("$select"): map[string]interface{}{
 					"type":        "string",
-					"description": "Comma-separated list of properties to select",
+					"description": "Comma-separated list of properties to select (property names; SAP labels are in include_metadata under entity_types_detail.<Entity>.properties[].sap_label)",
 				},
 				b.getParameterName("$top"): map[string]interface{}{
 					"type":        "integer",
@@ -524,7 +537,7 @@ func (b *ODataMCPBridge) generateGetTool(entitySetName string, entitySet *models
 			if prop.Name == keyProp {
 				properties[keyProp] = map[string]interface{}{
 					"type":        b.getJSONSchemaType(prop.Type),
-					"description": fmt.Sprintf("Key property: %s", keyProp),
+					"description": b.describeProperty("Key property", prop),
 				}
 				required = append(required, keyProp)
 				break
@@ -535,7 +548,7 @@ func (b *ODataMCPBridge) generateGetTool(entitySetName string, entitySet *models
 	// Add optional query parameters
 	properties[b.getParameterName("$select")] = map[string]interface{}{
 		"type":        "string",
-		"description": "Comma-separated list of properties to select",
+		"description": "Comma-separated list of properties to select (property names; SAP labels are in include_metadata under entity_types_detail.<Entity>.properties[].sap_label)",
 	}
 	properties[b.getParameterName("$expand")] = map[string]interface{}{
 		"type":        "string",
@@ -590,7 +603,7 @@ func (b *ODataMCPBridge) generateCreateTool(entitySetName string, entitySet *mod
 
 		properties[prop.Name] = map[string]interface{}{
 			"type":        b.getJSONSchemaType(prop.Type),
-			"description": fmt.Sprintf("Property: %s", prop.Name),
+			"description": b.describeProperty("Property", prop),
 		}
 
 		if !prop.Nullable {
@@ -645,7 +658,7 @@ func (b *ODataMCPBridge) generateUpdateTool(entitySetName string, entitySet *mod
 			if prop.Name == keyProp {
 				properties[keyProp] = map[string]interface{}{
 					"type":        b.getJSONSchemaType(prop.Type),
-					"description": fmt.Sprintf("Key property: %s", keyProp),
+					"description": b.describeProperty("Key property", prop),
 				}
 				required = append(required, keyProp)
 				break
@@ -656,10 +669,10 @@ func (b *ODataMCPBridge) generateUpdateTool(entitySetName string, entitySet *mod
 	// Add updatable properties (optional)
 	for _, prop := range entityType.Properties {
 		if !prop.IsKey {
-			properties[prop.Name] = map[string]interface{}{
-				"type":        b.getJSONSchemaType(prop.Type),
-				"description": fmt.Sprintf("Property: %s", prop.Name),
-			}
+		properties[prop.Name] = map[string]interface{}{
+			"type":        b.getJSONSchemaType(prop.Type),
+			"description": b.describeProperty("Property", prop),
+		}
 		}
 	}
 
@@ -712,7 +725,7 @@ func (b *ODataMCPBridge) generateDeleteTool(entitySetName string, entitySet *mod
 			if prop.Name == keyProp {
 				properties[keyProp] = map[string]interface{}{
 					"type":        b.getJSONSchemaType(prop.Type),
-					"description": fmt.Sprintf("Key property: %s", keyProp),
+					"description": b.describeProperty("Key property", prop),
 				}
 				required = append(required, keyProp)
 				break

--- a/internal/metadata/parser.go
+++ b/internal/metadata/parser.go
@@ -62,6 +62,7 @@ type Property struct {
 	MaxLength string   `xml:"MaxLength,attr"`
 	Precision string   `xml:"Precision,attr"`
 	Scale     string   `xml:"Scale,attr"`
+	SAPLabel  string   `xml:"sap:label,attr"`
 }
 
 // NavigationProperty represents a navigation property
@@ -181,6 +182,10 @@ func parseEntityType(et EntityType) *models.EntityType {
 			Type:     prop.Type,
 			Nullable: prop.Nullable != "false", // Default to true if not specified
 			IsKey:    contains(entityType.KeyProperties, prop.Name),
+		}
+		if prop.SAPLabel != "" {
+			label := prop.SAPLabel
+			property.SAPLabel = &label
 		}
 		entityType.Properties = append(entityType.Properties, property)
 	}

--- a/internal/metadata/parser.go
+++ b/internal/metadata/parser.go
@@ -62,7 +62,8 @@ type Property struct {
 	MaxLength string   `xml:"MaxLength,attr"`
 	Precision string   `xml:"Precision,attr"`
 	Scale     string   `xml:"Scale,attr"`
-	SAPLabel  string   `xml:"sap:label,attr"`
+	SAPLabel  string     `xml:"{http://www.sap.com/Protocols/SAPData}label,attr"`
+	Attrs     []xml.Attr `xml:",any,attr"`
 }
 
 // NavigationProperty represents a navigation property
@@ -183,8 +184,11 @@ func parseEntityType(et EntityType) *models.EntityType {
 			Nullable: prop.Nullable != "false", // Default to true if not specified
 			IsKey:    contains(entityType.KeyProperties, prop.Name),
 		}
-		if prop.SAPLabel != "" {
-			label := prop.SAPLabel
+		label := prop.SAPLabel
+		if label == "" {
+			label = sapLabelFromAttrs(prop.Attrs)
+		}
+		if label != "" {
 			property.SAPLabel = &label
 		}
 		entityType.Properties = append(entityType.Properties, property)
@@ -277,4 +281,18 @@ func contains(slice []string, item string) bool {
 		}
 	}
 	return false
+}
+
+func sapLabelFromAttrs(attrs []xml.Attr) string {
+	for _, attr := range attrs {
+		if attr.Name.Local != "label" {
+			continue
+		}
+		if attr.Name.Space == "http://www.sap.com/Protocols/SAPData" ||
+			strings.Contains(attr.Name.Space, "sap") ||
+			attr.Name.Space == "" {
+			return attr.Value
+		}
+	}
+	return ""
 }

--- a/internal/metadata/parser.go
+++ b/internal/metadata/parser.go
@@ -63,6 +63,7 @@ type Property struct {
 	Precision string   `xml:"Precision,attr"`
 	Scale     string   `xml:"Scale,attr"`
 	SAPLabel  string     `xml:"{http://www.sap.com/Protocols/SAPData}label,attr"`
+	SAPAggregationRole string `xml:"{http://www.sap.com/Protocols/SAPData}aggregation-role,attr"`
 	Attrs     []xml.Attr `xml:",any,attr"`
 }
 
@@ -191,6 +192,13 @@ func parseEntityType(et EntityType) *models.EntityType {
 		if label != "" {
 			property.SAPLabel = &label
 		}
+		aggRole := prop.SAPAggregationRole
+		if aggRole == "" {
+			aggRole = sapAttrFromAttrs(prop.Attrs, "aggregation-role")
+		}
+		if aggRole != "" {
+			property.SAPAggregationRole = &aggRole
+		}
 		entityType.Properties = append(entityType.Properties, property)
 	}
 
@@ -284,8 +292,12 @@ func contains(slice []string, item string) bool {
 }
 
 func sapLabelFromAttrs(attrs []xml.Attr) string {
+	return sapAttrFromAttrs(attrs, "label")
+}
+
+func sapAttrFromAttrs(attrs []xml.Attr, localName string) string {
 	for _, attr := range attrs {
-		if attr.Name.Local != "label" {
+		if attr.Name.Local != localName {
 			continue
 		}
 		if attr.Name.Space == "http://www.sap.com/Protocols/SAPData" ||

--- a/internal/metadata/parser_v4.go
+++ b/internal/metadata/parser_v4.go
@@ -96,6 +96,7 @@ type PropertyV4 struct {
 	Scale        string   `xml:"Scale,attr"`
 	Unicode      string   `xml:"Unicode,attr"`
 	DefaultValue string   `xml:"DefaultValue,attr"`
+	SAPLabel     string   `xml:"sap:label,attr"`
 }
 
 // NavigationPropertyV4 represents a navigation property in OData v4
@@ -286,6 +287,10 @@ func parseEntityTypeV4(et EntityTypeV4) *models.EntityType {
 			Type:     normalizeTypeV4(prop.Type),
 			Nullable: prop.Nullable != "false",
 			IsKey:    contains(entityType.KeyProperties, prop.Name),
+		}
+		if prop.SAPLabel != "" {
+			label := prop.SAPLabel
+			property.SAPLabel = &label
 		}
 		entityType.Properties = append(entityType.Properties, property)
 	}

--- a/internal/metadata/parser_v4.go
+++ b/internal/metadata/parser_v4.go
@@ -96,7 +96,8 @@ type PropertyV4 struct {
 	Scale        string   `xml:"Scale,attr"`
 	Unicode      string   `xml:"Unicode,attr"`
 	DefaultValue string   `xml:"DefaultValue,attr"`
-	SAPLabel     string   `xml:"sap:label,attr"`
+	SAPLabel     string     `xml:"{http://www.sap.com/Protocols/SAPData}label,attr"`
+	Attrs        []xml.Attr `xml:",any,attr"`
 }
 
 // NavigationPropertyV4 represents a navigation property in OData v4
@@ -288,8 +289,11 @@ func parseEntityTypeV4(et EntityTypeV4) *models.EntityType {
 			Nullable: prop.Nullable != "false",
 			IsKey:    contains(entityType.KeyProperties, prop.Name),
 		}
-		if prop.SAPLabel != "" {
-			label := prop.SAPLabel
+		label := prop.SAPLabel
+		if label == "" {
+			label = sapLabelFromAttrs(prop.Attrs)
+		}
+		if label != "" {
 			property.SAPLabel = &label
 		}
 		entityType.Properties = append(entityType.Properties, property)

--- a/internal/metadata/parser_v4.go
+++ b/internal/metadata/parser_v4.go
@@ -97,6 +97,7 @@ type PropertyV4 struct {
 	Unicode      string   `xml:"Unicode,attr"`
 	DefaultValue string   `xml:"DefaultValue,attr"`
 	SAPLabel     string     `xml:"{http://www.sap.com/Protocols/SAPData}label,attr"`
+	SAPAggregationRole string `xml:"{http://www.sap.com/Protocols/SAPData}aggregation-role,attr"`
 	Attrs        []xml.Attr `xml:",any,attr"`
 }
 
@@ -295,6 +296,13 @@ func parseEntityTypeV4(et EntityTypeV4) *models.EntityType {
 		}
 		if label != "" {
 			property.SAPLabel = &label
+		}
+		aggRole := prop.SAPAggregationRole
+		if aggRole == "" {
+			aggRole = sapAttrFromAttrs(prop.Attrs, "aggregation-role")
+		}
+		if aggRole != "" {
+			property.SAPAggregationRole = &aggRole
 		}
 		entityType.Properties = append(entityType.Properties, property)
 	}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -9,6 +9,7 @@ type EntityProperty struct {
 	Nullable    bool    `json:"nullable"`
 	IsKey       bool    `json:"is_key"`
 	Description *string `json:"description,omitempty"`
+	SAPLabel    *string `json:"sap_label,omitempty"`
 }
 
 // EntityType represents an OData entity type definition

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -10,6 +10,7 @@ type EntityProperty struct {
 	IsKey       bool    `json:"is_key"`
 	Description *string `json:"description,omitempty"`
 	SAPLabel    *string `json:"sap_label,omitempty"`
+	SAPAggregationRole *string `json:"sap_aggregation_role,omitempty"`
 }
 
 // EntityType represents an OData entity type definition

--- a/internal/test/sap_label_test.go
+++ b/internal/test/sap_label_test.go
@@ -1,0 +1,52 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/zmcp/odata-mcp/internal/metadata"
+)
+
+func TestSAPLabelParsingV2(t *testing.T) {
+	xmlData := `<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx Version="1.0"
+  xmlns:edmx="http://schemas.microsoft.com/ado/2007/06/edmx"
+  xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata"
+  xmlns:sap="http://www.sap.com/Protocols/SAPData">
+  <edmx:DataServices m:DataServiceVersion="2.0">
+    <Schema Namespace="Test" xmlns="http://schemas.microsoft.com/ado/2008/09/edm">
+      <EntityType Name="Foo">
+        <Key>
+          <PropertyRef Name="ID"/>
+        </Key>
+        <Property Name="ID" Type="Edm.String" Nullable="false" sap:label="Identifier"/>
+        <Property Name="Bar" Type="Edm.String" sap:label="Bar Label"/>
+      </EntityType>
+      <EntityContainer Name="TestContainer">
+        <EntitySet Name="Foos" EntityType="Test.Foo"/>
+      </EntityContainer>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>`
+
+	meta, err := metadata.ParseMetadata([]byte(xmlData), "http://example.com/")
+	if err != nil {
+		t.Fatalf("ParseMetadata failed: %v", err)
+	}
+
+	et := meta.EntityTypes["Foo"]
+	if et == nil {
+		t.Fatalf("Entity type Foo not found")
+	}
+
+	var barLabel *string
+	for _, prop := range et.Properties {
+		if prop.Name == "Bar" {
+			barLabel = prop.SAPLabel
+			break
+		}
+	}
+
+	if barLabel == nil || *barLabel != "Bar Label" {
+		t.Fatalf("Expected SAP label 'Bar Label', got %v", barLabel)
+	}
+}

--- a/internal/test/sap_label_test.go
+++ b/internal/test/sap_label_test.go
@@ -19,7 +19,7 @@ func TestSAPLabelParsingV2(t *testing.T) {
           <PropertyRef Name="ID"/>
         </Key>
         <Property Name="ID" Type="Edm.String" Nullable="false" sap:label="Identifier"/>
-        <Property Name="Bar" Type="Edm.String" sap:label="Bar Label"/>
+        <Property Name="Bar" Type="Edm.String" sap:label="Bar Label" sap:aggregation-role="dimension"/>
       </EntityType>
       <EntityContainer Name="TestContainer">
         <EntitySet Name="Foos" EntityType="Test.Foo"/>
@@ -39,14 +39,19 @@ func TestSAPLabelParsingV2(t *testing.T) {
 	}
 
 	var barLabel *string
+	var barAggRole *string
 	for _, prop := range et.Properties {
 		if prop.Name == "Bar" {
 			barLabel = prop.SAPLabel
+			barAggRole = prop.SAPAggregationRole
 			break
 		}
 	}
 
 	if barLabel == nil || *barLabel != "Bar Label" {
 		t.Fatalf("Expected SAP label 'Bar Label', got %v", barLabel)
+	}
+	if barAggRole == nil || *barAggRole != "dimension" {
+		t.Fatalf("Expected SAP aggregation role 'dimension', got %v", barAggRole)
 	}
 }


### PR DESCRIPTION
I've added a little feature (which helped me in what I was doing) which also takes into account the `sap:label=` from a certain $metadata endpoint, if there exists one.

So for example, if you have an extry like this in the XML $metadata:

```xml
<Property Name="A0MATERIAL" Type="Edm.String" MaxLength="40" sap:aggregation-role="dimension" sap:text="A0MATERIAL_T" sap:label="Material" sap:creatable="false" sap:updatable="false"/>
```

Calling the  `odata_service_info_for_Z_V_MM03` with `Include detailed metadata information` turned on, the result will look like:

entity_types_detail/<entity_name>/properties/<index> entry will also look like:
```json
6:
{
name:"A0MATERIAL",
type:"Edm.String",
nullable:true,
is_key:false,
sap_label:"Material"
}
```

Also added a test case for it.

Now: Just for a headsup, and I'm sorry in advance: I have no idea how to write Go, I just needed it for something and this is the best GPT5.2-Codex running in Codex CLI could whip out.


In reality, maybe this should be under some flag? And the structure of the patch probably doesn't even match with the way PR's are usually filed in here, but take it with a grain of salt in case anyone needs this.

Again, i know Open source is already inundated with AI slop and  I don't wanna contribute to it that much, but yeah, if you need it, feel free to clone / build from my branch