### PR TITLE
Tool execution errors should be returned as tool results with isError: true and fix error response formatting

### DIFF
--- a/internal/client/response.go
+++ b/internal/client/response.go
@@ -144,7 +144,7 @@ func (c *ODataClient) parseErrorFromBody(body []byte, statusCode int) error {
 		} `json:"error"`
 	}
 
-	if err := json.Unmarshal(body, &rawError); err == nil && rawError.Error.Code != "" {
+	if err := json.Unmarshal(body, &rawError); err == nil && rawError.Error.Message != nil {
 		// Extract message - handle both formats
 		var message string
 		switch m := rawError.Error.Message.(type) {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"strings"
 	"sync"
 
 	"github.com/zmcp/odata-mcp/internal/constants"
@@ -333,21 +332,26 @@ func (s *Server) handleToolsCallV2(req *Request) (*transport.Message, error) {
 
 	result, err := handler(handlerCtx, params)
 	if err != nil {
-		// Map OData errors to appropriate MCP error codes and provide detailed context
-		errorCode, errorMessage, errorData := s.categorizeError(err, name)
-		return s.createErrorResponse(req.ID, errorCode, errorMessage, errorData), nil
+		// Map OData errors, tool execution errors are returned as successful responses with isError flag
+		return s.createResponse(req.ID, map[string]interface{}{
+			"content": []map[string]interface{}{
+				{
+					"type": "text", 
+					"text": fmt.Sprintf("OData MCP tool '%s' failed: %s", name, err.Error()),
+				},
+			},
+			"isError": true,
+		})
 	}
 
-	response := map[string]interface{}{
+	return s.createResponse(req.ID, map[string]interface{}{
 		"content": []map[string]interface{}{
 			{
 				"type": "text",
 				"text": result,
 			},
 		},
-	}
-
-	return s.createResponse(req.ID, response)
+	})
 }
 
 // handlePingV2 handles the ping request for transport
@@ -394,66 +398,3 @@ func (s *Server) SendNotification(method string, params interface{}) error {
 	return s.transport.WriteMessage(msg)
 }
 
-// categorizeError maps OData errors to appropriate MCP error codes and enhances error messages
-func (s *Server) categorizeError(err error, toolName string) (int, string, string) {
-	errStr := err.Error()
-
-	// Create a comprehensive error message that includes both context and details
-	// The MCP client will see this as the main error message
-	fullErrorMessage := fmt.Sprintf("OData MCP tool '%s' failed: %s", toolName, errStr)
-
-	// Create structured data for programmatic use (though most clients ignore this)
-	errorData := fmt.Sprintf("{\"tool\":\"%s\",\"original_error\":\"%s\"}", toolName, errStr)
-
-	// Check for specific OData error patterns and map to appropriate MCP codes
-	switch {
-	case strings.Contains(errStr, "HTTP 400") || strings.Contains(errStr, "Bad Request"):
-		return -32602, fullErrorMessage, errorData
-
-	case strings.Contains(errStr, "HTTP 401") || strings.Contains(errStr, "Unauthorized"):
-		return -32603, fullErrorMessage, errorData
-
-	case strings.Contains(errStr, "HTTP 403") || strings.Contains(errStr, "Forbidden"):
-		return -32603, fullErrorMessage, errorData
-
-	case strings.Contains(errStr, "HTTP 404") || strings.Contains(errStr, "Not Found"):
-		return -32602, fullErrorMessage, errorData
-
-	case strings.Contains(errStr, "HTTP 409") || strings.Contains(errStr, "Conflict"):
-		return -32603, fullErrorMessage, errorData
-
-	case strings.Contains(errStr, "HTTP 422") || strings.Contains(errStr, "Unprocessable"):
-		return -32602, fullErrorMessage, errorData
-
-	case strings.Contains(errStr, "HTTP 429") || strings.Contains(errStr, "Too Many Requests"):
-		return -32603, fullErrorMessage, errorData
-
-	case strings.Contains(errStr, "HTTP 500") || strings.Contains(errStr, "Internal Server Error"):
-		return -32603, fullErrorMessage, errorData
-
-	case strings.Contains(errStr, "HTTP 502") || strings.Contains(errStr, "Bad Gateway"):
-		return -32603, fullErrorMessage, errorData
-
-	case strings.Contains(errStr, "HTTP 503") || strings.Contains(errStr, "Service Unavailable"):
-		return -32603, fullErrorMessage, errorData
-
-	case strings.Contains(errStr, "CSRF token"):
-		return -32603, fullErrorMessage, errorData
-
-	case strings.Contains(errStr, "timeout") || strings.Contains(errStr, "deadline exceeded"):
-		return -32603, fullErrorMessage, errorData
-
-	case strings.Contains(errStr, "connection refused") || strings.Contains(errStr, "network"):
-		return -32603, fullErrorMessage, errorData
-
-	case strings.Contains(errStr, "invalid metadata") || strings.Contains(errStr, "metadata"):
-		return -32603, fullErrorMessage, errorData
-
-	case strings.Contains(errStr, "invalid entity") || strings.Contains(errStr, "entity not found"):
-		return -32602, fullErrorMessage, errorData
-
-	default:
-		// Generic internal error with full context
-		return -32603, fullErrorMessage, errorData
-	}
-}


### PR DESCRIPTION
**1. Tool execution errors should be returned as tool results with isError: true (mcp/server.go)**
Currently, when wrong input parameters are passed to a tool the server would return a JSON-RPC error and hang (waiting for response), this does **not** allow the LLM to self-correct and retry with adjusted parameters. 
Reference; https://modelcontextprotocol.io/specification/2025-11-25/server/tools#error-handling

**2. Fix error response formatting (client/response):**
The OData v2 spec specifies an error to return an object with both a code and a message. The code is optional while the message is mandatory. The current implementation checks for a Code while it should check for a Message.

**Before:** the error returned looks like (because a fallback is used):
```
HTTP 400: {"error":{"code":"","message":{"lang":"en-GB","value":"Unknown function 'contains' at position 0."}}}
```
**After:**
```
OData error (HTTP 400): Unknown function 'contains' at position 0.
```