### PR TITLE
fix(mcp): handle notifications/initialized as a JSON-RPC notification

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -162,7 +162,23 @@ func (s *Server) HandleMessage(ctx context.Context, msg *transport.Message) (*tr
 	}
 
 	// Handle notifications (no response expected)
-	if req.Method == "initialized" {
+	// if req.Method == "initialized" {
+	// 	s.handleInitialized(req)
+	// 	return nil, nil
+	// }
+
+	// Handle notifications (no response expected per JSON-RPC 2.0).
+	// A notification is any message with no "id" field.
+	if msg.ID == nil || (len(msg.ID) > 0 && string(msg.ID) == "null") {
+		if req.Method == "notifications/initialized" || req.Method == "initialized" {
+			s.handleInitialized(req)
+		}
+		// For any other notification we don't recognize, silently drop it.
+		return nil, nil
+	}
+
+	// Backstop: also accept "notifications/initialized" even if a client incorrectly sends it with an id.
+	if req.Method == "notifications/initialized" || req.Method == "initialized" {
 		s.handleInitialized(req)
 		return nil, nil
 	}


### PR DESCRIPTION
Previously, the server matched only the bare method name 'initialized' and fell through to the default case for 'notifications/initialized', emitting a -32601 error response. Because null IDs were coerced to 0 in createErrorResponse, that error reused id 0 (already consumed by the initialize request), which Claude Code 2.1.117 rejects with 'Received a response for an unknown message ID', tearing down the transport.

This change detects notifications by the absence of an id (per JSON-RPC 2.0 sec 4.1) and silently no-ops unrecognized ones, and accepts both 'notifications/initialized' and the legacy short form 'initialized'.